### PR TITLE
Small typo in the instructions of the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Apache 2.0
 Install openapi python stubs:
 > pip3 install openapi
 
-Get an API key from OpenAPI and either store it in the environment variable OPENAI_API_KEY or alternatively set it in a file apikey.py (i.e. apikey="...").
+Get an API key from OpenAI and either store it in the environment variable OPENAI_API_KEY or alternatively set it in a file apikey.py (i.e. apikey="...").
 
 Run it:
 > python3 macLLM.py


### PR DESCRIPTION
I believe it was meant to say get an API key from OpenAI, not OpenAPI